### PR TITLE
Update min ver for CA

### DIFF
--- a/systemStats.xml
+++ b/systemStats.xml
@@ -4,6 +4,7 @@
 <PluginURL>https://raw.github.com/bergware/dynamix/master/unRAIDv6/dynamix.system.stats.plg</PluginURL>
 <PluginAuthor>Bergware</PluginAuthor>
 <Beta>False</Beta>
+<MinVer>6.4.0</MinVer>
 <Category>Tools:System</Category>
 <Name>Dynamix System Stats</Name>
 <Description>


### PR DESCRIPTION
If it wasn't possible for .plgs to have things like Base64 encoded files, etc that can really bloat the size of a .plg, I would've had the application feed include .plgs instead of the additional xml's

Of course, this PR makes things strange, since the plugin system won't allow updates to system stats on 6.3.5, but FCP will still tag stats as being incompatible if you're running 6.3.5 Have to think about how to handle that case, but probably won't happen too often going forward.